### PR TITLE
Small updates on mobile

### DIFF
--- a/components/Homepage/AsSeenIn.tsx
+++ b/components/Homepage/AsSeenIn.tsx
@@ -48,7 +48,7 @@ export const AsSeenIn: React.FC = () => {
             <Flex flexDirection="row" flexWrap="wrap" alignItems="center" style={{ width: "100%" }}>
               {mobileIcons.map((item, index) => {
                 return (
-                  <Box mr={2} mb={2} key={index}>
+                  <Box mr="20px" mb={3} key={index}>
                     <img src={item.iconHref} style={{ maxHeight: "20px" }} />
                   </Box>
                 )

--- a/components/Homepage/FAQ.tsx
+++ b/components/Homepage/FAQ.tsx
@@ -41,7 +41,7 @@ export const FAQ: React.FC = () => {
   return (
     <Grid>
       <Box px={[2, 0]} mb={6}>
-        <Sans px={0.5} size="5">
+        <Sans px={0.5} size={["8", "5"]}>
           Frequently asked questions
         </Sans>
       </Box>

--- a/components/Homepage/Hero.tsx
+++ b/components/Homepage/Hero.tsx
@@ -64,7 +64,6 @@ const MobileHero = () => {
               <Sans size="8" color="black100">
                 This is Seasons.
               </Sans>
-              <Spacer mb={1} />
               <Sans size="8" color="black50">
                 An invite-only rental subscription service for menswear & streetware.
               </Sans>

--- a/components/Homepage/MembershipCard.tsx
+++ b/components/Homepage/MembershipCard.tsx
@@ -34,7 +34,7 @@ export const MembershipCard: React.FC<{ type: MembershipType }> = ({ type }) => 
             alignItems="center"
             justifyContent="center"
           >
-            <Flex style={{ height: "100%" }} p={5} flexDirection="column" justifyContent="space-between">
+            <Flex style={{ height: "100%" }} p={[3, 5]} flexDirection="column" justifyContent="space-between">
               <Sans size="6">{planInfo.planName}</Sans>
               <Box>
                 <Sans size="6">{planInfo.boldText}</Sans>

--- a/components/Homepage/ProductRail.tsx
+++ b/components/Homepage/ProductRail.tsx
@@ -11,9 +11,9 @@ export const ProductRail: React.FC<{ products: any; title?: string }> = ({ produ
   return (
     <Grid>
       <Flex flexDirection="row" justifyContent={!!title ? "space-between" : "flex-end"} px={["2", "0"]} mx={0.5}>
-        {title && <Sans size="6">{title}</Sans>}
+        {title && <Sans size={["5", "6"]}>{title}</Sans>}
         <Link href="/browse">
-          <Sans size="6">See all</Sans>
+          <Sans size={["5", "6"]}>See all</Sans>
         </Link>
       </Flex>
       <Spacer mb={2} />


### PR DESCRIPTION
- "Just added" font-size: 20 --> 18px
- "Frequently asked questions" font-size 18px --> 24px
- remove break between "this is seasons" and second line
- add padding between logos so they're not bunched together
- on the membership option blocks, decrease padding from 40px to 24px on the left side