### PR TITLE
Small fix in footer

### DIFF
--- a/components/About/AboutFooter.tsx
+++ b/components/About/AboutFooter.tsx
@@ -66,7 +66,7 @@ export const AboutFooter: React.FC = () => {
       <Grid>
         <Row>
           <Col md="6" xs="12">
-            <Box py={[10, 5]} px={[2, 0]} style={{ width: "100%" }}>
+            <Box py={[10, 5]} px={[2, 0]} width="100%">
               <Sans size="6">Who we’re backed by</Sans>
               <Spacer mb={5} />
               {backers.map((backer) => (

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -22,7 +22,7 @@ export const Footer = () => {
             Terms of Service
           </Sans>
         </Link>
-        <Spacer mb={[1, 0]} />
+        <Spacer mb={[1, 0]} mr={[0, 2]} />
         <Link href="/privacy-policy">
           <Sans size="4" color={color("black50")} pt="0.5" pr="3">
             Privacy Policy


### PR DESCRIPTION
- `padding` and `margin` had been removed from the `Sans` element, this fix adds spacing in the footer to remedy the lost padding.