### PR TITLE
Removes params if they exist in imageResize

### DIFF
--- a/utils/imageResize.ts
+++ b/utils/imageResize.ts
@@ -58,6 +58,7 @@ export const imageResize = (
   sizeName: ImageResizerSize,
   passedOptions: ImageResizerOptions = { fit: "clip" }
 ) => {
+  const removedParams = url.split("?")[0]
   const options: ImageResizerOptions = pickBy(
     {
       fit: "clip",
@@ -85,10 +86,12 @@ export const imageResize = (
   }
 
   if (/seasons-images\./.test(url)) {
-    return url.replace(`seasons-images.s3.amazonaws.com`, `seasons-s3.imgix.net`) + "?" + qs.stringify(params)
+    return removedParams.replace(`seasons-images.s3.amazonaws.com`, `seasons-s3.imgix.net`) + "?" + qs.stringify(params)
   }
 
   return (
-    url.replace(`seasons-images-staging.s3.amazonaws.com`, `seasons-s3-staging.imgix.net`) + "?" + qs.stringify(params)
+    removedParams.replace(`seasons-images-staging.s3.amazonaws.com`, `seasons-s3-staging.imgix.net`) +
+    "?" +
+    qs.stringify(params)
   )
 }


### PR DESCRIPTION
- Unfortunately for now we can't remove the `imageResize` helper in flare because we need it when getting two sizes for the same image, for the `ProgressiveImageLoader` - although now that the images are much smaller we could revisit not using that loader.
- This fixes malformed query params due to default params being passed by the initial query 