### PR TITLE
Update apple-app-site-association

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -7,8 +7,11 @@
         "/a/account",
         "/a/account/create",
         "/a/account/login",
+        "/a/account/*",
+        
+        "/browse",
         "/browse/*",
-        "/product/*/", 
+        "/product/*",
       ]
     }]
   }


### PR DESCRIPTION
Remove trailing `/` on `product` route, add `/a/account/*`, and add `/browse` .