### PR TITLE
Adds status Waitlisted to addCustomerDetails mutation

### DIFF
--- a/pages/signup/[signup].tsx
+++ b/pages/signup/[signup].tsx
@@ -42,6 +42,7 @@ const ADD_MEASUREMENTS = gql`
   ) {
     addCustomerDetails(
       details: { height: $height, weight: $weight, topSizes: $topSizes, waistSizes: $waistSizes }
+      status: Waitlisted
       event: CompletedWaitlistForm
     ) {
       id


### PR DESCRIPTION
We left out `status: Waitlisted` on the `addCustomerDetails` call here. That was why we had users who had completed all the waitlist info but still had status `Created`. This PR fixes that.