### PR TITLE
Include custom metadata for product pages

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,21 +1,28 @@
 import { Theme } from "../lib/theme"
-import { Nav } from "./Nav"
+import { Box } from "./Box"
 import { Footer } from "./Footer"
 import { LayoutHead } from "./LayoutHead"
-import { Box } from "./Box"
 import { MaxWidth } from "./MaxWidth"
+import { Nav } from "./Nav"
 
 interface LayoutProps {
   fixedNav?: boolean
   hideFooter?: boolean
   children?: any
   footerBottomPadding?: string | string[]
+  includeDefaultHead?: boolean
 }
 
-export const Layout = ({ fixedNav = false, children, hideFooter, footerBottomPadding }: LayoutProps) => {
+export const Layout = ({
+  fixedNav = false,
+  children,
+  hideFooter,
+  footerBottomPadding,
+  includeDefaultHead = true,
+}: LayoutProps) => {
   return (
     <>
-      <LayoutHead />
+      {includeDefaultHead && <LayoutHead />}
       <Theme>
         <Nav fixed={fixedNav} />
         <MaxWidth>

--- a/pages/product/[Product].tsx
+++ b/pages/product/[Product].tsx
@@ -1,19 +1,22 @@
-import { GET_PRODUCT } from "../../components/Product/ProductQueries"
-import React from "react"
-import { useQuery } from "@apollo/react-hooks"
-import withData from "../../lib/apollo"
-import { ProductDetails } from "../../components/Product/ProductDetails"
-import { Grid, Col, Row } from "../../components/Grid"
-import { Box, Layout, Spacer } from "../../components"
-import { ImageLoader, ProductTextLoader } from "../../components/Product/ProductLoader"
-import { ProgressiveImage } from "../../components/Image"
-import { HowItWorks } from "../../components/Product/HowItWorks"
-import { Button } from "../../components/Button"
-import { Media } from "../../components/Responsive"
-import { Carousel } from "../../components/Carousel"
-import { Schema, screenTrack } from "../../utils/analytics"
+import Head from "next/head"
 import { withRouter } from "next/router"
+import React from "react"
+
+import { useQuery } from "@apollo/react-hooks"
+
+import { Box, Layout, Spacer } from "../../components"
+import { Button } from "../../components/Button"
+import { Carousel } from "../../components/Carousel"
+import { Col, Grid, Row } from "../../components/Grid"
+import { ProgressiveImage } from "../../components/Image"
 import { Link } from "../../components/Link"
+import { HowItWorks } from "../../components/Product/HowItWorks"
+import { ProductDetails } from "../../components/Product/ProductDetails"
+import { ImageLoader, ProductTextLoader } from "../../components/Product/ProductLoader"
+import { GET_PRODUCT } from "../../components/Product/ProductQueries"
+import { Media } from "../../components/Responsive"
+import withData from "../../lib/apollo"
+import { Schema, screenTrack } from "../../utils/analytics"
 
 const Product = withData(
   screenTrack(({ router }) => {
@@ -33,8 +36,23 @@ const Product = withData(
 
     const product = data && data.product
 
+    const title = `${product?.name} by ${product?.brand?.name}`
+    const description = product && product.description
+
     return (
-      <Layout fixedNav>
+      <Layout fixedNav includeDefaultHead={false}>
+        <Head>
+          <title>{`${title} - Seasons`}</title>
+          <meta content={description} name="description" />
+          <meta property="og:title" content={title} />
+          <meta property="og:description" content={description} />
+          <meta property="twitter:description" content={description} />
+          <meta property="og:type" content="website" />
+          <meta property="og:site_name" content="Seasons" />
+          <meta property="og:url" content={`https://www.seasons.nyc/product/${slug}`} />
+          <meta property="og:image" content={product?.images?.[0].url} />
+          <meta property="twitter:card" content="summary" />
+        </Head>
         <Box pt={[1, 5]}>
           <Grid>
             <Row>


### PR DESCRIPTION
Adds custom metadata for product pages in flare

<img width="1329" alt="Screen Shot 2020-09-29 at 11 36 20 AM" src="https://user-images.githubusercontent.com/296775/94580510-03d31c80-0248-11eb-94d0-ffd3f5babcb8.png">
