### PR TITLE
QA fixes

### DIFF
--- a/components/Homepage/Hero.tsx
+++ b/components/Homepage/Hero.tsx
@@ -5,13 +5,12 @@ import { Flex, Sans, Spacer, Box, MaxWidth, Picture, Separator } from "../"
 import { Display } from "../Typography"
 import { GetTheAppButton } from "../Button/GetTheApp"
 import Link from "next/link"
-import { imageResize } from "../../utils/imageResize"
 import { Media } from "../Responsive"
 import { Button } from "../Button"
 import { Check } from "../SVGs"
 
 const imageURL = require("../../public/images/homepage/Hero-Image-10-29-20.png")
-const headerText = "Wear, Swap, Repeat"
+const headerText = "Wear,Swap,Repeat"
 
 const listText = [
   "Free shipping, returns & dry cleaning.",
@@ -23,8 +22,9 @@ const DesktopTextContent = () => {
   return (
     <Box pb={5} style={{ zIndex: 3, position: "relative" }} pr={2}>
       <Flex flexDirection="column" justifyContent="center" alignItems="center" height="100%">
-        <Flex style={{ flex: 1 }} flexDirection="column" justifyContent="center">
-          <Display size="10" color="black100">
+        <Flex flexDirection="column" justifyContent="center">
+          <Spacer mb={10} />
+          <Display size="10" color="black100" style={{ letterSpacing: "-2px" }}>
             {headerText}
           </Display>
           <Spacer mb={1} />
@@ -58,8 +58,8 @@ const DesktopTextContent = () => {
 const DesktopHero = ({ post }) => {
   return (
     <MaxWidth>
-      <Box width="100%" px={[2, 2, 2, 5, 5]} py={5}>
-        <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+      <Box width="100%" px={[2, 2, 2, 5, 5]} pb={5}>
+        <Flex flexDirection="row" justifyContent="space-between">
           <DesktopTextContent />
           <StyledAnchor href={post?.url}>
             <BackgroundImage style={{ backgroundImage: `url(${post?.imageURL})` }} />
@@ -88,7 +88,7 @@ const MobileHero = ({ post }) => {
           <Flex flexDirection="column">
             <Flex style={{ flex: 1 }} flexDirection="column" justifyContent="center">
               <Spacer mb={10} />
-              <Display size="10" color="black100">
+              <Display size="10" color="black100" style={{ letterSpacing: "-2px" }}>
                 {headerText}
               </Display>
               <Spacer mb={1} />
@@ -176,6 +176,6 @@ const StyledAnchor = styled.a`
   color: inherit;
   cursor: pointer;
   width: 50%;
-  max-width: 700px;
+  max-width: 800px;
   min-height: 450px;
 `

--- a/components/Nav/SeasonsLogo.tsx
+++ b/components/Nav/SeasonsLogo.tsx
@@ -8,7 +8,9 @@ export const SeasonsLogo: React.FC<BoxProps> = () => {
     <Link href="/">
       <StyledAnchor href="/">
         <LogoContainer>
-          <Display size="8">SEASONS</Display>
+          <Display size="8" style={{ letterSpacing: "1px" }}>
+            SEASONS
+          </Display>
         </LogoContainer>
       </StyledAnchor>
     </Link>

--- a/components/Product/HowItWorks.tsx
+++ b/components/Product/HowItWorks.tsx
@@ -21,7 +21,7 @@ export const HOW_IT_WORKS_TEXT = [
 
 export const HowItWorks = () => {
   return (
-    <Box pt={10} px={2} mb={3}>
+    <Box pt={10} mb={3}>
       <Sans size="5" color="black100">
         How it works
       </Sans>

--- a/components/Product/ProductDetails.tsx
+++ b/components/Product/ProductDetails.tsx
@@ -31,7 +31,7 @@ export const ProductDetails: React.FC<{
   }
 
   return (
-    <Box px={2} mb={3}>
+    <Box mb={3}>
       <Flex flexDirection="row" justifyContent="space-between">
         <Box>
           <VariantSizes variants={product.variants} size="3" />

--- a/components/Product/ProductInfoItem.tsx
+++ b/components/Product/ProductInfoItem.tsx
@@ -16,7 +16,7 @@ export const ProductInfoItem: React.FC<Props> = ({ detailType, detailValue, hide
         <Sans size="4" color="black">
           {detailType}
         </Sans>
-        <Sans size="4" color="gray">
+        <Sans size="4" color="black50" style={{ textAlign: "right" }}>
           {detailValue}
         </Sans>
       </Flex>

--- a/components/Typography/Typography.tsx
+++ b/components/Typography/Typography.tsx
@@ -211,7 +211,7 @@ function createStyledText<P extends StyledTextProps>(
     if (fontFamilyType === null) {
       throw new Error("Did not expect `fontType` to be `null`.")
     }
-    const styles = fontType === "display" ? { ...textProps.style, letterSpacing: "-1px" } : textProps.style
+    const styles = fontType === "display" ? { letterSpacing: "-1px", ...textProps.style } : textProps.style
     return (
       <Text
         fontFamily={fontFamilyType && fontFamily[fontType][fontFamilyType]}

--- a/lib/theme.tsx
+++ b/lib/theme.tsx
@@ -181,11 +181,11 @@ export const themeProps = {
     container: {
       padding: 0,
       maxWidth: {
-        xl: 1800,
-        lg: 1800,
-        md: 1800,
-        sm: 1800,
-        xs: 1800,
+        xl: 1500,
+        lg: 1500,
+        md: 1500,
+        sm: 1500,
+        xs: 1500,
       },
     },
     row: {

--- a/pages/browse/[filter].tsx
+++ b/pages/browse/[filter].tsx
@@ -321,7 +321,7 @@ const Pagination = styled.div<{ currentPage: number; pageCount: number }>`
 `
 
 const FixedBox = styled.div`
-  position: absolute;
+  position: relative;
   height: 100%;
   overflow: scroll;
   ::-webkit-scrollbar {

--- a/pages/index/index.tsx
+++ b/pages/index/index.tsx
@@ -20,6 +20,32 @@ import { screenTrack, Schema } from "../../utils/analytics"
 import { BRAND_LIST } from "../../components/Homepage/Brands"
 import { HOW_IT_WORKS_TEXT } from "../../components/Product/HowItWorks"
 
+const HomePageProductFragment = gql`
+  fragment HomePageProduct on Product {
+    id
+    slug
+    name
+    images {
+      url
+      id
+    }
+    brand {
+      id
+      name
+    }
+    variants {
+      id
+      total
+      reservable
+      nonReservable
+      reserved
+      internalSize {
+        display
+      }
+    }
+  }
+`
+
 export const HOME_QUERY = gql`
   query GetBrowseProducts($brandSlugs: [String!]) {
     paymentPlans(where: { status: "active" }) {
@@ -53,27 +79,7 @@ export const HOME_QUERY = gql`
       orderBy: publishedAt_DESC
       where: { AND: [{ variants_some: { id_not: null } }, { status: Available }] }
     ) {
-      id
-      slug
-      name
-      images {
-        url
-        id
-      }
-      brand {
-        id
-        name
-      }
-      variants {
-        id
-        total
-        reservable
-        nonReservable
-        reserved
-        internalSize {
-          display
-        }
-      }
+      ...HomePageProduct
     }
     justAddedBottoms: products(
       first: 4
@@ -81,29 +87,17 @@ export const HOME_QUERY = gql`
       orderBy: publishedAt_DESC
       where: { AND: [{ variants_some: { id_not: null } }, { status: Available }] }
     ) {
-      id
-      slug
-      name
-      images {
-        url
-        id
-      }
-      brand {
-        id
-        name
-      }
-      variants {
-        id
-        total
-        reservable
-        nonReservable
-        reserved
-        internalSize {
-          display
-        }
-      }
+      ...HomePageProduct
+    }
+    newArchival: products(
+      first: 4
+      orderBy: publishedAt_DESC
+      where: { AND: [{ tags_some: { name: "Vintage" } }, { status: Available }] }
+    ) {
+      ...HomePageProduct
     }
   }
+  ${HomePageProductFragment}
 `
 
 const Home = screenTrack(() => ({
@@ -134,24 +128,21 @@ const Home = screenTrack(() => ({
 
         <Spacer mb={10} />
         <ProductRail title="Just added tops" products={data?.justAddedTops} />
-        <Spacer mb={8} />
-
-        <Box px={[2, 2, 2, 5, 5]}>
-          <Separator />
-        </Box>
 
         <Spacer mb={10} />
         <FromCommunity blogPosts={communityPosts} />
-        <Spacer mb={10} />
 
         {!!data?.justAddedBottoms?.length && (
           <>
-            <Box px={[2, 2, 2, 5, 5]}>
-              <Separator />
-            </Box>
-
             <Spacer mb={10} />
             <ProductRail title="Just added bottoms" products={data?.justAddedBottoms} />
+            <Spacer mb={10} />
+          </>
+        )}
+
+        {!!data?.newArchival?.length && (
+          <>
+            <ProductRail title="New to the archive" products={data?.newArchival} />
             <Spacer mb={10} />
           </>
         )}

--- a/pages/product/[Product].tsx
+++ b/pages/product/[Product].tsx
@@ -53,10 +53,10 @@ const Product = withApollo({ ssr: true })(
           <meta property="og:image" content={product?.images?.[0].url.replace("fm=webp", "fm=jpg")} />
           <meta property="twitter:card" content="summary" />
         </Head>
-        <Box pt={[1, 5]}>
+        <Box pt={[1, 5]} px={[0, 0, 2, 5, 5]}>
           <Grid>
             <Row>
-              <Col md="6" sm="12">
+              <Col md="7" sm="12">
                 <Media greaterThanOrEqual="md">
                   <Box>
                     {!product ? (
@@ -64,7 +64,7 @@ const Product = withApollo({ ssr: true })(
                     ) : (
                       product?.images.map((image) => {
                         return (
-                          <Box px={[2, 2, 2, 5, 5]} mb={0.5} key={image.url}>
+                          <Box pl={[2, 2, 0, 0, 0]} pr={[2, 2, 2, 5, 5]} mb={0.5} key={image.url}>
                             <ProgressiveImage imageUrl={image.url} size="large" alt="product image" />
                           </Box>
                         )
@@ -79,9 +79,9 @@ const Product = withApollo({ ssr: true })(
                 </Media>
               </Col>
               <Col md="5" sm="12">
-                <Box mr={[0, 4]}>
+                <Box style={{ maxWidth: "390px" }}>
                   {product ? <ProductDetails product={product} /> : <ProductTextLoader />}
-                  <Box px={2}>
+                  <Box>
                     <Link href="/signup">
                       <Button width="100%" block variant="primaryWhite" onClick={null}>
                         Create an account
@@ -94,7 +94,7 @@ const Product = withApollo({ ssr: true })(
             </Row>
           </Grid>
         </Box>
-        <Spacer mb="125px" />
+        <Spacer mb={10} />
       </Layout>
     )
   })


### PR DESCRIPTION
## All pages
1px letter-spacing on word mark
Max-width of 1500px

## Homepage
Drop the spaces between wear,swap,repeat and use -2px spacing on that title
Add a padding-top: 80px to the left hero block (copy & cta’s) 
Max-width of 800px on the hero content block (currently 750px)
Archival homepage rail

## Browse
Separate scroll views, categories + designers and product
Tapping next (pagination) reloads the left pane of designers and categories

## Product pages
lets use 55% max-width on product images here if we go with 1500px max-width on the site