### PR TITLE
Directs /a/account pages to szns.co/app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "next build",
     "start": "next start -p $PORT",
     "upload-assets": "node scripts/uploadAssetsToS3.js",
-    "heroku-cleanup": "yarn upload-assets"
+    "heroku-cleanup": "yarn upload-assets",
+    "prettier": "prettier --write 'pages/**/*.{js,ts,tsx,md,graphql}' --ignore-path ./.prettierignore"
   },
   "engines": {
     "node": "12"
@@ -73,7 +74,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^4.1.2",
-    "prettier": "2.0.4",
+    "prettier": "^2.1.2",
     "typescript": "^3.7.5"
   },
   "prettier": {

--- a/pages/a/account/[Account].tsx
+++ b/pages/a/account/[Account].tsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from "react"
+import { Nav } from "../../../components/Nav/Nav"
+import { Layout} from "../../../components"
+import { screenTrack, Schema } from "../../../utils/analytics"
+import { useRouter } from "next/router"
+
+const A = (path: string) => screenTrack(() => ({
+  page: Schema.PageNames.App,
+  path: `${path}`,
+}))(() => {
+  const router = useRouter()
+  useEffect(() => {router.push("https://szns.co/app")})
+  return (
+    <Layout fixedNav>
+      <Nav fixed />
+    </Layout>
+  )
+})
+
+export default A

--- a/pages/a/account/create.tsx
+++ b/pages/a/account/create.tsx
@@ -1,0 +1,2 @@
+import A from "./[Account]"
+export default A("create")

--- a/pages/a/account/index.tsx
+++ b/pages/a/account/index.tsx
@@ -1,0 +1,2 @@
+import A from "./[Account]"
+export default A("")

--- a/pages/a/account/login.tsx
+++ b/pages/a/account/login.tsx
@@ -1,0 +1,2 @@
+import A from "./[Account]"
+export default A("login")

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,15 @@
 import { Box, Layout, Separator, Spacer } from "components"
 import {
-  Brands, ChooseMembership, ColumnList, FAQ, FromCommunity, Hero, MembershipBenefits, ProductRail,
-  TheApp, TheBag
+  Brands,
+  ChooseMembership,
+  ColumnList,
+  FAQ,
+  FromCommunity,
+  Hero,
+  MembershipBenefits,
+  ProductRail,
+  TheApp,
+  TheBag,
 } from "components/Homepage"
 import { BRAND_LIST } from "components/Homepage/Brands"
 import { Nav } from "components/Nav/Nav"

--- a/utils/analytics/schema/index.ts
+++ b/utils/analytics/schema/index.ts
@@ -67,6 +67,7 @@ export enum PageNames {
   AboutPage = "About",
   PrivacyPolicy = "PrivacyPolicy",
   TermsOfService = "TermsOfService",
+  App = "App"
 }
 
 export enum EntityTypes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5885,10 +5885,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
-  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
 private@^0.1.6:
   version "0.1.8"


### PR DESCRIPTION
- `/a/account`, `/a/account/create/` and `/a/account/login` all redirect to szns.co/app. This is important because we deep link some of these pages in our emails, and we don't want to lose people to a 404 while we wait to get to web parity.