### PR TITLE
Updates GET_STATIC_PRODUCTS

### DIFF
--- a/pages/product/[Product].tsx
+++ b/pages/product/[Product].tsx
@@ -12,7 +12,7 @@ import { initializeApollo } from "lib/apollo"
 import { useAuthContext } from "lib/auth/AuthContext"
 import Head from "next/head"
 import { withRouter } from "next/router"
-import { GET_PRODUCT, GET_PRODUCTS } from "queries/productQueries"
+import { GET_PRODUCT, GET_STATIC_PRODUCTS } from "queries/productQueries"
 import React, { useEffect, useState } from "react"
 import { Schema, screenTrack } from "utils/analytics"
 
@@ -130,7 +130,7 @@ export async function getStaticPaths() {
   const apolloClient = initializeApollo()
 
   const response = await apolloClient.query({
-    query: GET_PRODUCTS,
+    query: GET_STATIC_PRODUCTS,
   })
 
   const paths = []

--- a/queries/productQueries.ts
+++ b/queries/productQueries.ts
@@ -90,9 +90,9 @@ export const GET_PRODUCT = gql`
   }
 `
 
-export const GET_PRODUCTS = gql`
-  query GetProducts {
-    products(where: { status: Available }) {
+export const GET_STATIC_PRODUCTS = gql`
+  query GetStaticProducts {
+    products(where: { status: Available }, limit: 300, orderBy: "publishedAt_DESC") {
       id
       slug
     }


### PR DESCRIPTION
- Limits `GET_STATIC_PRODUCTS` to be 300 pages so we're not growing the heroku slug to be over 500mb