### PR TITLE
Triage Customer Fix

### DIFF
--- a/lib/auth/AuthProvider.tsx
+++ b/lib/auth/AuthProvider.tsx
@@ -88,7 +88,10 @@ export const AuthProvider = React.forwardRef<AuthProviderRef, AuthProviderProps>
       apolloClient.resetStore()
     },
     signOut: async () => {
-      localStorage.removeItem("userSession")
+      const keysToClear = ["userSession", "isWaitlisted", "allAccessEnabled"]
+      for (const key of keysToClear) {
+        localStorage.removeItem(key)
+      }
       analytics?.reset()
       dispatch({ type: "SIGN_OUT" })
       apolloClient.resetStore()


### PR DESCRIPTION
- Fixes a bug wherein if a user signed up, then logged out, then went through the sign up flow again, the `triageCustomer` mutation would not fire. This arose from not properly clearing the cache upon signout. 

