### PR TITLE
Fixes allAccessEnabled

### DIFF
--- a/components/Homepage/ChooseMembership.tsx
+++ b/components/Homepage/ChooseMembership.tsx
@@ -8,37 +8,15 @@ import { Col, Grid, Row } from "../Grid"
 import { Media } from "../Responsive"
 import { Check } from "../SVGs"
 import { Display } from "../Typography"
-import { useQuery } from "@apollo/client"
-import gql from "graphql-tag"
-
-export const ADMISSIONS_ME = gql`
-  query admissionsMe {
-    me {
-      customer {
-        id
-        admissions {
-          id
-          allAccessEnabled
-        }
-      }
-    }
-  }
-`
 
 interface ChooseMembershipProps {
   paymentPlans: any
   onSelectPlan?: (plan: any) => void
+  allAccessEnabled: boolean
 }
 
-export const ChooseMembership: React.FC<ChooseMembershipProps> = ({ paymentPlans, onSelectPlan }) => {
-  const { data, loading } = useQuery(ADMISSIONS_ME, {
-    onCompleted: (data) => {
-      localStorage.setItem("allAccessEnabled", data?.me?.customer?.admissions?.allAccessEnabled)
-    },
-  })
-
+export const ChooseMembership: React.FC<ChooseMembershipProps> = ({ paymentPlans, onSelectPlan, allAccessEnabled }) => {
   const plansGroupedByTier = []
-  const allAccessEnabled = data?.me?.customer?.admissions?.allAccessEnabled
   const tiers = uniq(paymentPlans?.map((plan) => plan.tier))
   tiers?.forEach((tier) => {
     const tierPlans = paymentPlans?.filter((plan) => {
@@ -49,9 +27,6 @@ export const ChooseMembership: React.FC<ChooseMembershipProps> = ({ paymentPlans
     plansGroupedByTier.push(tierPlans)
   })
 
-  if (!data) {
-    return null
-  }
   return (
     <>
       <Media greaterThanOrEqual="md">
@@ -73,7 +48,7 @@ export const ChooseMembership: React.FC<ChooseMembershipProps> = ({ paymentPlans
 }
 
 const Content = ({ tier, descriptionLines, group, onSelectPlan, allAccessEnabled }) => {
-  const renderingDisabledAllAccess = tier === "AllAccess" && !allAccessEnabled
+  const renderingDisabledAllAccess = tier === "AllAccess" && typeof allAccessEnabled === "boolean" && !allAccessEnabled
 
   const calcFinalPrice = (price: number) => {
     let couponData
@@ -202,12 +177,16 @@ const Content = ({ tier, descriptionLines, group, onSelectPlan, allAccessEnabled
             )
           })}
       </Flex>
-      <Spacer mb={1} />
-      {renderingDisabledAllAccess && (
-        <Sans color="black50" size="3">
-          * All Access is disabled in your area due to shipping time.
-        </Sans>
-      )}
+      <Box style={{ position: "relative" }}>
+        {renderingDisabledAllAccess && (
+          <NoteWrapper>
+            <Spacer mb={1} />
+            <Sans color="black50" size="3">
+              * All Access is disabled in your area due to shipping time.
+            </Sans>
+          </NoteWrapper>
+        )}
+      </Box>
     </>
   )
 }
@@ -286,4 +265,10 @@ const PlanWrapper = styled(Box)<{ withHover: boolean }>`
   &:hover {
     box-shadow: ${(props) => (props.withHover ? "0 4px 12px 0 rgba(0, 0, 0, 0.2)" : "none")};
   }
+`
+
+const NoteWrapper = styled(Box)`
+  position: absolute;
+  bottom: -16px;
+  left: 0;
 `

--- a/components/Login/Login.tsx
+++ b/components/Login/Login.tsx
@@ -7,10 +7,10 @@ import React, { useState } from "react"
 
 import { useMutation } from "@apollo/client"
 import { Box, colors, Fade, Slide, styled } from "@material-ui/core"
-import { ADMISSIONS_ME } from "components/Homepage/ChooseMembership"
 import { Link } from "components/Link"
 import { ResetPassword } from "mobile/LogIn/ResetPassword"
-import { GET_USER } from "mobile/Account/Account"
+import { HOME_QUERY } from "queries/homeQueries"
+import { PAYMENT_PLANS } from "components/SignUp/ChoosePlanStep"
 
 const LOG_IN = gql`
   mutation LogIn($email: String!, $password: String!) {
@@ -44,7 +44,7 @@ export const LoginView: React.FunctionComponent<LoginViewProps> = (props) => {
       }
     },
     awaitRefetchQueries: true,
-    refetchQueries: [{ query: ADMISSIONS_ME }],
+    refetchQueries: [{ query: HOME_QUERY }, { query: PAYMENT_PLANS }],
   })
 
   const handleSubmit = async ({ email, password }) => {

--- a/components/SignUp/ChoosePlanStep.tsx
+++ b/components/SignUp/ChoosePlanStep.tsx
@@ -19,6 +19,15 @@ export const PAYMENT_PLANS = gql`
       tier
       itemCount
     }
+    me {
+      customer {
+        id
+        admissions {
+          id
+          allAccessEnabled
+        }
+      }
+    }
   }
 `
 
@@ -86,6 +95,8 @@ export const ChoosePlanStep: React.FC<ChoosePlanStepProps> = ({ onPlanSelected, 
     })
   }, [])
 
+  const allAccessEnabled = data?.me?.customer?.admissions?.allAccessEnabled
+
   function executeChargebeeCheckout(planID) {
     // @ts-ignore
     const chargebee = Chargebee.getInstance()
@@ -117,6 +128,7 @@ export const ChoosePlanStep: React.FC<ChoosePlanStepProps> = ({ onPlanSelected, 
       </Box>
       <Spacer mb={3} />
       <ChooseMembership
+        allAccessEnabled={allAccessEnabled}
         paymentPlans={data?.paymentPlans}
         onSelectPlan={async (plan) => {
           onPlanSelected(plan)

--- a/components/SignUp/TriageStep.tsx
+++ b/components/SignUp/TriageStep.tsx
@@ -1,10 +1,9 @@
 import gql from "graphql-tag"
 import React, { useEffect, useState } from "react"
-
 import { useMutation } from "@apollo/client"
-
 import { TriageProgressScreen } from "./TriageProgressScreen"
-import { ADMISSIONS_ME } from "components/Homepage/ChooseMembership"
+import { HOME_QUERY } from "queries/homeQueries"
+import { PAYMENT_PLANS } from "./ChoosePlanStep"
 
 const TRIAGE = gql`
   mutation triage {
@@ -36,7 +35,7 @@ export const TriageStep: React.FC<TriagePaneProps> = ({ check, onTriageComplete 
     onError: (err) => {
       console.log("Error TriagePane.tsx:", err)
     },
-    refetchQueries: [{ query: ADMISSIONS_ME }],
+    refetchQueries: [{ query: HOME_QUERY }, { query: PAYMENT_PLANS }],
     awaitRefetchQueries: true,
   })
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,8 +34,8 @@ const Home = screenTrack(() => ({
   })
 
   const communityPosts = data?.blogPosts?.slice(1, 3)
-
   const featuredBrandItems = navigationData?.brands || []
+  const allAccessEnabled = data?.me?.customer?.admissions?.allAccessEnabled
 
   return (
     <Layout fixedNav brandItems={featuredBrandItems}>
@@ -75,7 +75,7 @@ const Home = screenTrack(() => ({
         <Separator />
       </Box>
 
-      <ChooseMembership paymentPlans={data?.paymentPlans} />
+      <ChooseMembership allAccessEnabled={allAccessEnabled} paymentPlans={data?.paymentPlans} />
 
       <Box px={[2, 2, 2, 5, 5]}>
         <Separator />

--- a/queries/homeQueries.ts
+++ b/queries/homeQueries.ts
@@ -28,6 +28,15 @@ const HomePageProductFragment = gql`
 
 export const HOME_QUERY = gql`
   query GetBrowseProducts {
+    me {
+      customer {
+        id
+        admissions {
+          id
+          allAccessEnabled
+        }
+      }
+    }
     paymentPlans(where: { status: "active" }) {
       id
       name


### PR DESCRIPTION
- Removes query for querying `allAccessEnabled` as it was a duplicate query
- Fixes styling so there isn't empty space pushing down the separator
- Renders All Access plans unless the customer has `allAccessEnabled === false`, so that the home page plan section renders without being disabled. 