### PR TITLE
fix: enable formik validateOnChange, don't recreate submit button on props change

### DIFF
--- a/components/Forms/FormsTemplate.tsx
+++ b/components/Forms/FormsTemplate.tsx
@@ -63,6 +63,30 @@ const BackButton = ({ onClick }) => {
   )
 }
 
+const SubmitButton = ({ buttonActionName, tracking, handleSubmit, isSubmitting, disabled, buttonText }) => {
+  return (
+    <Button
+      ml={2}
+      variant="primaryBlack"
+      onClick={() => {
+        if (!!buttonActionName) {
+          tracking.trackEvent({
+            actionName: buttonActionName,
+            actionType: Schema.ActionTypes.Tap,
+          })
+        }
+        handleSubmit()
+      }}
+      loading={isSubmitting}
+      size="medium"
+      type="submit"
+      disabled={disabled}
+    >
+      {buttonText}
+    </Button>
+  )
+}
+
 export const FormFooter: React.FC<FooterProps> = ({
   buttonText,
   handleSubmit,
@@ -73,29 +97,6 @@ export const FormFooter: React.FC<FooterProps> = ({
   buttonActionName,
 }) => {
   const tracking = useTracking()
-  const ButtonComponent = () => {
-    return (
-      <Button
-        ml={2}
-        variant="primaryBlack"
-        onClick={() => {
-          if (!!buttonActionName) {
-            tracking.trackEvent({
-              actionName: buttonActionName,
-              actionType: Schema.ActionTypes.Tap,
-            })
-          }
-          handleSubmit()
-        }}
-        loading={isSubmitting}
-        size="medium"
-        type="submit"
-        disabled={disabled}
-      >
-        {buttonText}
-      </Button>
-    )
-  }
 
   return (
     <FormFooterWrapper>
@@ -117,10 +118,26 @@ export const FormFooter: React.FC<FooterProps> = ({
             ) : null}
             {!!buttonText && !!buttonLink ? (
               <a href={buttonLink}>
-                <ButtonComponent />
+                <SubmitButton
+                  buttonActionName={buttonActionName}
+                  tracking={tracking}
+                  handleSubmit={handleSubmit}
+                  isSubmitting={isSubmitting}
+                  disabled={disabled}
+                  buttonText={buttonText}
+                />
               </a>
             ) : (
-              !!buttonText && <ButtonComponent />
+              !!buttonText && (
+                <SubmitButton
+                  buttonActionName={buttonActionName}
+                  tracking={tracking}
+                  handleSubmit={handleSubmit}
+                  isSubmitting={isSubmitting}
+                  disabled={disabled}
+                  buttonText={buttonText}
+                />
+              )
             )}
           </Flex>
         </MaxWidth>

--- a/components/Forms/Wizard.tsx
+++ b/components/Forms/Wizard.tsx
@@ -142,7 +142,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
         //@ts-ignore
         validate={validate}
         validationSchema={validationSchema}
-        validateOnChange={false}
+        validateOnChange={true}
         onSubmit={this.handleSubmit}
       >
         {(formikRenderProps) => {


### PR DESCRIPTION
- re-enable formik `validateOnChange`, originally disabled [here](https://github.com/seasons/flare/commit/188d7520f810f9354dc9ba7d920163c246e4c414#diff-31bbba353aed6fe69427c6be0a08a03aafcd3f2eeafd107d859431bc69a54f70L144-R145)
- moves the form `SubmitButton` definition outside of `FormFooter`, as it was being recreated / remounted during a form input blur event (formik updates props somewhere I guess), which caused it to lose the first click event and required a second click in order to submit.

closes: https://app.asana.com/0/1142800780012669/1196663792239321