### PR TITLE
send utm params on signup

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -9,6 +9,7 @@ import { Footer } from "./Footer"
 import { LayoutHead } from "./LayoutHead"
 import { MaxWidth } from "./MaxWidth"
 import { Nav } from "./Nav"
+import { useRouter } from "next/router"
 import { PopUp } from "./PopUp"
 
 interface LayoutProps {
@@ -28,6 +29,21 @@ export const Layout = ({
   includeDefaultHead = true,
   brandItems,
 }: LayoutProps) => {
+  // If there are any UTM params, store them in a cookie
+  const router = useRouter()
+  const utm = {
+    source: router.query?.utm_source,
+    medium: router.query?.utm_medium,
+    campaign: router.query?.utm_campaign,
+    term: router.query?.utm_term,
+    content: router.query?.utm_content,
+  }
+  if (typeof window !== "undefined") {
+    if (!!utm.source || !!utm.medium || !!utm.campaign || !!utm.term || !!utm.content) {
+      localStorage?.setItem("utm", JSON.stringify(utm))
+    }
+  }
+
   return (
     <>
       {includeDefaultHead && <LayoutHead />}

--- a/lib/auth/AuthProvider.tsx
+++ b/lib/auth/AuthProvider.tsx
@@ -97,7 +97,7 @@ export const AuthProvider = React.forwardRef<AuthProviderRef, AuthProviderProps>
       apolloClient.resetStore()
     },
     signOut: async () => {
-      const keysToClear = ["userSession", "isWaitlisted", "allAccessEnabled"]
+      const keysToClear = ["userSession", "isWaitlisted", "allAccessEnabled", "utm"]
       for (const key of keysToClear) {
         localStorage.removeItem(key)
       }

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -30,6 +30,7 @@ const SIGN_UP_USER = gql`
     $lastName: String!
     $details: CustomerDetailCreateInput!
     $referrerId: String
+    $utm: UTMInput
   ) {
     signup(
       email: $email
@@ -38,6 +39,7 @@ const SIGN_UP_USER = gql`
       lastName: $lastName
       details: $details
       referrerId: $referrerId
+      utm: $utm
     ) {
       expiresIn
       refreshToken
@@ -148,8 +150,7 @@ const SignUpPage = screenTrack(() => ({
       validationSchema={createAccountValidationSchema}
       onSubmit={async (values, actions) => {
         try {
-          signOut()
-
+          const utm = JSON.parse(localStorage?.getItem("utm"))
           const date = new Date(values.dob)
           const dateToIso = DateTime.fromJSDate(date).toISO()
           const firstName = values.firstName.charAt(0).toUpperCase() + values.firstName.slice(1)
@@ -169,6 +170,7 @@ const SignUpPage = screenTrack(() => ({
                 },
               },
               referrerId: router.query.referrer_id,
+              utm,
             },
           })
 


### PR DESCRIPTION
Works with  https://github.com/seasons/monsoon/pull/727/files. 

- If a user visits the website with a link that includes utm params, stores the params in a cookie and sends them along with the `signup` mutation.