### PR TITLE
feat: update measurements sign up step

### DIFF
--- a/components/Fields/DateField.tsx
+++ b/components/Fields/DateField.tsx
@@ -2,10 +2,9 @@ import React, { useState } from "react"
 import { Field } from "formik"
 import { FormProps } from "../Forms/FormsTemplate"
 import { TextField } from "./TextField"
-import { String } from "aws-sdk/clients/networkmanager"
 
 interface Props extends FormProps {
-  inputName: String
+  inputName: string
 }
 
 export const DateField: React.FC<Props> = ({ context, inputName }) => {

--- a/components/Fields/MultiSelectionTableField.tsx
+++ b/components/Fields/MultiSelectionTableField.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { useField } from "formik"
+import {
+  MultiSelectionTable,
+  Props as MultiSelectionTableProps,
+  Item,
+} from "../../mobile/GetMeasurementsPane/MultiSelectionTable"
+
+type Props = Pick<MultiSelectionTableProps, "items" | "itemSize" > & {
+  inputName: string
+}
+
+export const MultiSelectionTableField: React.FC<Props> = ({ inputName, items, itemSize }) => {
+  const [{ value }, _, { setValue, setTouched }] = useField<string[]>(inputName)
+
+  const handleTap = (item: Item, _index: number) => {
+    const idx = value.findIndex((i) => i === item.value)
+    const newValue = [...value]
+    if (idx === -1) {
+      newValue.push(item.value)
+    } else {
+      newValue.splice(idx, 1)
+    }
+    setValue(newValue)
+    setTouched(true)
+  }
+
+  const selectedItemIndices = value.map((item) => items.findIndex((innerItem) => innerItem.value === item))
+
+  return (
+    <MultiSelectionTable
+      items={items}
+      onTap={handleTap}
+      selectedItemIndices={selectedItemIndices}
+      itemSize={itemSize}
+    />
+  )
+}

--- a/components/Forms/CustomerMeasurementsForm.tsx
+++ b/components/Forms/CustomerMeasurementsForm.tsx
@@ -1,9 +1,10 @@
-import { ExternalLink } from "components"
+import { ExternalLink, Box } from "components"
 import React from "react"
 import { Schema } from "utils/analytics"
 import * as Yup from "yup"
 
 import { FormProps, FormTemplate } from "./FormsTemplate"
+import { MultiSelectionTableField } from "../Fields/MultiSelectionTableField"
 import { customerMeasurements } from "./helpers/measurements"
 
 export interface CustomerMeasurementsFormFields {
@@ -53,17 +54,27 @@ export const CustomerMeasurementsForm = ({ context }: FormProps) => {
         },
         {
           name: "topSizes",
-          selectOptions: customerMeasurements.topSizes,
+          customElement: (
+            <Box mt={1}>
+              <MultiSelectionTableField inputName={"topSizes"} items={customerMeasurements.topSizes} itemSize={64} />
+            </Box>
+          ),
           placeholder: "Select",
-          multiple: true,
           label: "What are your preferred top sizes?",
           mobileOrder: 3,
         },
         {
           name: "waistSizes",
-          selectOptions: customerMeasurements.waistSizes,
+          customElement: (
+            <Box mt={1}>
+              <MultiSelectionTableField
+                inputName={"waistSizes"}
+                items={customerMeasurements.waistSizes}
+                itemSize={64}
+              />
+            </Box>
+          ),
           placeholder: "Select",
-          multiple: true,
           label: "Preferred waist sizes?",
           mobileOrder: 4,
         },

--- a/components/Forms/helpers/measurements.ts
+++ b/components/Forms/helpers/measurements.ts
@@ -33,7 +33,7 @@ const topSizes: SelectItem[] = [
 const waistSizes: SelectItem[] = (() => {
   const items: SelectItem[] = []
   for (let waistSize = 28; waistSize <= 40; waistSize++) {
-    items.push({ label: `${String(waistSize)}"`, value: waistSize })
+    items.push({ label: String(waistSize), value: waistSize })
   }
   return items
 })()

--- a/mobile/GetMeasurementsPane/MultiSelectionTable.tsx
+++ b/mobile/GetMeasurementsPane/MultiSelectionTable.tsx
@@ -1,32 +1,28 @@
-import { Box, Flex, Sans, Spacer } from "components"
+import { Flex, Sans } from "components"
 import { color } from "helpers/color"
-import React, { useState } from "react"
-import { Dimensions, TouchableOpacity, ViewStyle } from "react-native"
+import React from "react"
+import { TouchableOpacity, ViewStyle } from "react-native"
 import styled from "styled-components"
 
-type Item = { label: string; value: string }
+export type Item = { label: string; value: string }
 
-interface MultiSelectionTableProps {
+export interface Props {
   disabled?: boolean
   items: Item[]
   onTap?: (item: Item, index: number) => void
   selectedItemIndices: number[]
   style?: ViewStyle
+  itemSize?: number
 }
 
-const windowWidth = Dimensions.get("window").width - 32
-
-export const MultiSelectionTable: React.FC<MultiSelectionTableProps> = ({
+export const MultiSelectionTable: React.FC<Props> = ({
   disabled = false,
   items,
   onTap,
   selectedItemIndices,
+  itemSize = 60,
 }) => {
-  const [width, setWidth] = useState(windowWidth)
-
-  const itemHeight = 60
   const itemCornerRadius = 4
-  const minimumInterItemSpacing = 8
 
   const data = items.map((item, index) => ({
     isSelected: selectedItemIndices.includes(index),
@@ -36,13 +32,13 @@ export const MultiSelectionTable: React.FC<MultiSelectionTableProps> = ({
   const renderItem = ({ isSelected, item }: { isSelected: boolean; item: Item }, index: number) => {
     return (
       <TouchableOpacity disabled={disabled} onPress={() => onTap?.(item, index)} key={index}>
-        <Flex height={itemHeight + interItemSpacing} width={itemHeight} mr={1} justifyContent="center">
+        <Flex height={itemSize} width={itemSize} mr={1} justifyContent="center">
           <Flex
             justifyContent="center"
-            height={itemHeight + "px"}
-            width={itemHeight + "px"}
+            height={itemSize + "px"}
+            width={itemSize + "px"}
             style={{
-              backgroundColor: color(isSelected ? "black04" : "white100"),
+              backgroundColor: color(isSelected ? "black100" : "white100"),
               borderColor: color(isSelected ? "black100" : "black10"),
               borderStyle: "solid",
               borderRadius: itemCornerRadius,
@@ -56,10 +52,10 @@ export const MultiSelectionTable: React.FC<MultiSelectionTableProps> = ({
           >
             <Sans
               size="3"
-              color="black100"
+              color={isSelected ? "white100" : "black100"}
               style={{
                 textAlign: "center",
-                lineHeight: itemHeight + "px",
+                lineHeight: itemSize + "px",
               }}
             >
               {item.label}
@@ -70,27 +66,11 @@ export const MultiSelectionTable: React.FC<MultiSelectionTableProps> = ({
     )
   }
 
-  const itemsPerRow = Math.floor((width - itemHeight) / (itemHeight + minimumInterItemSpacing)) + 1
-  const interItemSpacing = (width - itemsPerRow * itemHeight) / (itemsPerRow - 1)
-  const numRows = Math.ceil(items.length / itemsPerRow)
-  // @ts-ignore
-  const numArray = [...Array(numRows).keys()]
-
-  return (
-    <Box>
-      {numArray.map((
-        row // map each row index to a Flex box
-      ) => (
-        <Flex key={row.toString()} style={{ flexWrap: "wrap" }}>
-          {data.slice(row * itemsPerRow, (row + 1) * itemsPerRow).flatMap((datum, index, array) => {
-            const dataIndex = index + itemsPerRow * row
-            const view = renderItem(datum, dataIndex) // render each item
-            return view
-          })}
-        </Flex>
-      ))}
-    </Box>
-  )
+  return <Container itemSize={itemSize}>{data.map((datum, index) => renderItem(datum, index))}</Container>
 }
 
-const Container = styled(Box)``
+const Container = styled.div<Pick<Props, "itemSize">>`
+  display: grid;
+  gap: 7px 7px;
+  grid-template-columns: repeat(auto-fit, ${({ itemSize }) => `${itemSize}px`});
+`


### PR DESCRIPTION
Updates the measurements select picker in the sign up flow.

Closes: https://app.asana.com/0/1198999116706413/1199151024676807/f

It looks like our grid is a bit off vs the designs on desktop (50% width columns vs fixed 343px), so the layout differs a bit:

![localhost_3000_signup (1)](https://user-images.githubusercontent.com/5216744/99445906-374b3280-28ec-11eb-8ece-de8c8c0cd563.png)

The color change I made is global, so it also affects the same picker within the sizing tab. We could make this a prop if we want to keep the old styling.
![localhost_3000_ (2)](https://user-images.githubusercontent.com/5216744/99444826-b93a5c00-28ea-11eb-8477-f57dfaa73a12.png)
