### PR TITLE
fix: remove superfluous call to setTouched

### DIFF
--- a/components/Fields/MultiSelectionTableField.tsx
+++ b/components/Fields/MultiSelectionTableField.tsx
@@ -6,7 +6,7 @@ import {
   Item,
 } from "../../mobile/GetMeasurementsPane/MultiSelectionTable"
 
-type Props = Pick<MultiSelectionTableProps, "items" | "itemSize" > & {
+type Props = Pick<MultiSelectionTableProps, "items" | "itemSize"> & {
   inputName: string
 }
 
@@ -15,14 +15,13 @@ export const MultiSelectionTableField: React.FC<Props> = ({ inputName, items, it
 
   const handleTap = (item: Item, _index: number) => {
     const idx = value.findIndex((i) => i === item.value)
-    const newValue = [...value]
+    const newValue = [...value].filter(Boolean)
     if (idx === -1) {
       newValue.push(item.value)
     } else {
       newValue.splice(idx, 1)
     }
     setValue(newValue)
-    setTouched(true)
   }
 
   const selectedItemIndices = value.map((item) => items.findIndex((innerItem) => innerItem.value === item))


### PR DESCRIPTION
Fixes a validation issue reported [here](https://seasonsnyc.slack.com/archives/CU27UB7QA/p1605658260016200) - `setTouched` was superfluous and seems to create an issue with how validation interacted with the field - the first time toggling from an empty state to an array with a single value in either the waist or top sizes field would incorrectly fail validation.