### PR TITLE
feat: port save product modal from harvest

### DIFF
--- a/components/Product/ProductDetails.tsx
+++ b/components/Product/ProductDetails.tsx
@@ -1,4 +1,4 @@
-import { SaveProductButton } from "mobile/SaveProductButton"
+import { SaveProductButton } from "mobile/Product/SaveProductButton"
 import Link from "next/link"
 import React from "react"
 
@@ -40,7 +40,7 @@ export const ProductDetails: React.FC<{
           <Flex flexDirection="row" justifyContent="space-between" width="100%">
             <VariantSizes variants={product.variants} size="3" />
             <Box>
-              <SaveProductButton product={product} selectedVariant={selectedVariant} />
+              <SaveProductButton product={product} selectedVariant={selectedVariant} showSizeSelector={true} />
             </Box>
           </Flex>
           <Box my={2}>

--- a/components/index.ts
+++ b/components/index.ts
@@ -15,6 +15,7 @@ export { Skeleton } from "./Skeleton"
 export { Theme } from "lib/theme"
 export { Toggle } from "./Toggle"
 export { TextInput } from "./TextInput"
+export { ProgressiveImage } from "./Image"
 
 export * from "./Typography"
 export * from "./Responsive"

--- a/mobile/Product/SaveProduct.tsx
+++ b/mobile/Product/SaveProduct.tsx
@@ -1,0 +1,234 @@
+import { useMutation } from "@apollo/client"
+import React, { useState } from "react"
+import { FlatList, TouchableWithoutFeedback } from "react-native"
+import styled from "styled-components"
+import { GET_PRODUCT } from "queries/productQueries"
+import { Box, Button, ProgressiveImage, Flex, Sans, Separator, Spacer, FixedBackArrow } from "components"
+import Radio from "@material-ui/core/Radio"
+import { sizeToName } from "components/Product/VariantSelect"
+import { Loader } from "mobile/Loader"
+import { GET_BAG } from "queries/bagQueries"
+import { color, space } from "helpers"
+import { Schema, screenTrack, useTracking } from "utils/analytics"
+import { SAVE_ITEM } from "./SaveProductButton"
+
+interface SaveProductProps {
+  onDismiss: () => void;
+  product: any;
+}
+
+export const SaveProduct: React.FC<SaveProductProps> = screenTrack()(({ product, onDismiss }) => {
+  const tracking = useTracking()
+  const [selectedVariantID, setSelectedVariantID] = useState(null)
+  const [saveItem] = useMutation(SAVE_ITEM, {
+    refetchQueries: [
+      {
+        query: GET_PRODUCT,
+        variables: {
+          slug: product?.slug
+        },
+      },
+      {
+        query: GET_BAG,
+      },
+    ],
+  })
+
+  if (!product) {
+    return (
+      <>
+        <FixedBackArrow onPress={onDismiss} />
+        <Loader />
+      </>
+    )
+  }
+
+  // largeImages come from product query and images come from browse query
+  const images = product?.largeImages || product.images
+
+  const { description, name, type, variants } = product
+
+  const brandName = product?.brand?.name
+
+  if (!type) {
+    return (
+      <>
+        <FixedBackArrow onPress={onDismiss} variant="whiteBackground" />
+        <Loader />
+      </>
+    )
+  }
+
+  const onSelectSize = (variantID) => {
+    tracking.trackEvent({
+      actionName: Schema.ActionNames.SizeButtonTapped,
+      actionType: Schema.ActionTypes.Tap,
+    })
+    setSelectedVariantID(variantID)
+  }
+
+  const renderItem = (item) => {
+    switch (item.type) {
+      case "Header":
+        return (
+          <>
+            <Spacer mt={2} />
+            <Flex flexDirection="row" justifyContent="space-between">
+              <Flex flex={2} flexDirection="column" justifyContent="flex-end">
+                <Sans size="3">{name}</Sans>
+                {!!brandName && (
+                  <Sans size="3" color={color("black50")}>
+                    {brandName}
+                  </Sans>
+                )}
+              </Flex>
+              <ImageContainer>
+                <ProgressiveImage alt="product image" size="small" imageUrl={images?.[0]?.url || ""} />
+              </ImageContainer>
+            </Flex>
+            <Spacer mt={2} />
+            <Sans size="3" color={color("black50")}>
+              {description}
+            </Sans>
+            <Spacer mt={2} />
+            <Separator />
+          </>
+        )
+      case "Sizes":
+        const renderSizeRow = (item) => {
+          const {
+            id,
+            internalSize: { bottom, top },
+            isSaved,
+          } = item
+          let sizeName
+          switch (type) {
+            case "Top":
+              sizeName = sizeToName(top?.letter)
+              break
+            case "Bottom":
+              sizeName = bottom?.value
+              break
+          }
+
+          return (
+            <TouchableWithoutFeedback onPress={() => onSelectSize(id)}>
+              <Box>
+                <Spacer mt={20} />
+                <Flex flexDirection="row" justifyContent="space-between">
+                  <Flex flexDirection="row" alignItems="center">
+                    <Radio checked={id === selectedVariantID} value={id} onChange={() => onSelectSize(id)} />
+                    <Sans color={color("black100")} ml={1} size="3" weight="medium">
+                      {sizeName}
+                    </Sans>
+                  </Flex>
+                  {isSaved && (
+                    <Sans color={color("black50")} size="3" weight="medium">
+                      (Saved)
+                    </Sans>
+                  )}
+                </Flex>
+                <Spacer mt={20} />
+                <Separator color={color("black10")} />
+              </Box>
+            </TouchableWithoutFeedback>
+          )
+        }
+        return (
+          <FlatList
+            extraData={{ selectedVariantID }}
+            data={item?.variants || []}
+            keyExtractor={(_item, index) => String(index)}
+            renderItem={({ item }) => renderSizeRow(item)}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  const onPressSaveBtn = () => {
+    saveItem({
+      variables: {
+        item: selectedVariantID,
+        save: true,
+      },
+      optimisticResponse: {
+        __typename: "Mutation",
+        saveProduct: {
+          __typename: "Product",
+          id: product.id,
+          productVariant: {
+            __typename: "ProductVariant",
+            isSaved: true,
+            id: selectedVariantID,
+          },
+        },
+      },
+    })
+    onDismiss()
+  }
+
+  const buttonHeight = 48
+  const sections = [{ type: "Header" }, { type: "Sizes", variants }]
+
+  return (
+    <Container>
+      <Box px={2}>
+        <FlatList
+          data={sections}
+          keyExtractor={(_item, index) => String(index)}
+          renderItem={({ item }) => renderItem(item)}
+          ListFooterComponent={() => <Spacer mb={buttonHeight + space(4)} />}
+        />
+      </Box>
+      <Flex alignItems={"stretch"} mb={2} px={2}>
+        <Box flex={1}>
+          <Button
+            block
+            variant="primaryWhite"
+            onClick={() => {
+              tracking.trackEvent({
+                actionName: Schema.ActionNames.SaveProductModalCancelTapped,
+                actionType: Schema.ActionTypes.Tap,
+              })
+              onDismiss()
+            }}
+          >
+            Cancel
+          </Button>
+        </Box>
+        <Spacer ml={2} />
+        <Box flex={1}>
+          <Button
+            block
+            disabled={selectedVariantID === null}
+            variant="primaryBlack"
+            onClick={() => {
+              tracking.trackEvent({
+                actionName: Schema.ActionNames.SaveProductModalSaveTapped,
+                actionType: Schema.ActionTypes.Tap,
+              })
+              onPressSaveBtn()
+            }}
+          >
+            Save
+          </Button>
+        </Box>
+      </Flex>
+    </Container>
+  )
+})
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: ${color("white100")};
+  border: solid 1px ${color("black100")};
+`
+
+const ImageContainer = styled.div`
+  background: #f6f6f6;
+  flex: 1;
+`

--- a/mobile/Product/SaveProductButton.tsx
+++ b/mobile/Product/SaveProductButton.tsx
@@ -8,6 +8,8 @@ import { useTracking, Schema } from "utils/analytics"
 import { GET_PRODUCT } from "queries/productQueries"
 import { GET_BAG } from "queries/bagQueries"
 import styled from "styled-components"
+import { SaveProduct } from "./SaveProduct"
+import { Modal } from "@material-ui/core"
 
 export const SAVE_ITEM = gql`
   mutation SaveItem($item: ID!, $save: Boolean!) {
@@ -41,6 +43,7 @@ export const SaveProductButton: React.FC<SaveProductButtonProps> = ({
   const isSaved = selectedVariant?.isSaved
     ? selectedVariant?.isSaved
     : product?.variants?.filter((variant) => variant.isSaved).length > 0
+  const [isPopUpVisible, setIsPopUpVisible] = useState(false)
   const [enabled, setEnabled] = useState(isSaved)
   const tracking = useTracking()
   const [saveItem] = useMutation(SAVE_ITEM, {
@@ -75,8 +78,9 @@ export const SaveProductButton: React.FC<SaveProductButtonProps> = ({
       return
     }
 
-    if (showSizeSelector) {
+    if (showSizeSelector && !isSaved) {
       // Open size selector window, e.g. user is on browse page
+      setIsPopUpVisible(true)
     } else {
       tracking.trackEvent({
         actionName: Schema.ActionNames.ProductSaved,
@@ -106,12 +110,32 @@ export const SaveProductButton: React.FC<SaveProductButtonProps> = ({
     }
   }
 
+  const handlePopUpDismiss = () => {
+    setIsPopUpVisible(false)
+  }
+
   return (
-    <Wrapper pl={2} pb={2} pt={0.5} onClick={handleSaveButton}>
-      <SaveIcon width={width ? width : 16} height={height ? height : 22} enabled={enabled} />
-    </Wrapper>
+    <>
+      <Wrapper pl={2} pb={2} pt={0.5} onClick={handleSaveButton}>
+        <SaveIcon width={width ? width : 16} height={height ? height : 22} enabled={enabled} />
+      </Wrapper>
+      <Modal open={isPopUpVisible} onClose={handlePopUpDismiss}>
+        <ModalRoot>
+          <SaveProduct product={product} onDismiss={handlePopUpDismiss}  />
+        </ModalRoot>
+      </Modal>
+    </>
   )
 }
+
+const ModalRoot = styled(Box)`
+  max-width: 800px;
+  margin: auto;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
 
 const Wrapper = styled(Box)`
   cursor: pointer;

--- a/utils/analytics/schema/index.ts
+++ b/utils/analytics/schema/index.ts
@@ -147,6 +147,9 @@ export enum ActionNames {
   NotificationToggleTapped = "Notification Toggle Tapped",
   AddCreditCardTapped = "AddCreditCardTapped",
   GetMeasurementsFinishTapped = "Get Measurements Finish Tapped",
+  SizeButtonTapped = "Size Button Tapped",
+  SaveProductModalCancelTapped = "Save Product Modal Cancel Tapped",
+  SaveProductModalSaveTapped = "Save Product Modal Save Tapped"
 }
 
 /**


### PR DESCRIPTION
Closes: https://app.asana.com/0/1198999116706413/1199201177261947/f

Ports the save product / size selector modal from harvest. Only shows it when you're saving (i.e. does not show it if you're unsaving a product.

![localhost_3000_product_stis-over-dyed-cotton-shell-fleece-lined-jacket-blue](https://user-images.githubusercontent.com/5216744/99555777-b002cb00-298e-11eb-9beb-7744288c79a3.png)

<img width=200 src="https://user-images.githubusercontent.com/5216744/99556048-096afa00-298f-11eb-90ba-770610547b91.png" />
