### PR TITLE
Fix analytics track events

### DIFF
--- a/utils/analytics/track.ts
+++ b/utils/analytics/track.ts
@@ -87,7 +87,7 @@ export function screenTrack<P>(trackingInfo?: TrackingInfo<Schema.PageViewEvent,
         console.log("[Event tracked]", JSON.stringify(newData, null, 2))
       }
       if (data.actionName) {
-        return analytics?.track(data.screen, newData)
+        return analytics?.track(data.actionName, newData)
       } else {
         return analytics?.page(newData)
       }


### PR DESCRIPTION
Our `track` analytics events were broken because `data.screen` is never set, this fixes the issue