### PR TITLE
fix: update homepage carousel images when prop changes

### DIFF
--- a/components/Homepage/HomepageCarousel.tsx
+++ b/components/Homepage/HomepageCarousel.tsx
@@ -26,6 +26,12 @@ export const HomepageCarousel: React.FC<{
     }
   }, [])
 
+  useEffect(() => {
+    if (clientSide) {
+      setImagesToUse(images)
+    }
+  }, [clientSide, images])
+
   if (!images) {
     return null
   }


### PR DESCRIPTION
Fixes an issue with stale designer carousel images displaying when you viewed a designer directly from another designer page.