### PR TITLE
feat: add cors headers to fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "aws-sdk": "^2.691.0",
     "babel-plugin-module-resolver": "^4.0.0",
     "chargebee": "^2.6.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "formik": "^2.1.4",
     "formik-material-ui": "^2.0.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require("express")
 const next = require("next")
+const cors = require("cors")
 
 const dev = process.env.NODE_ENV !== "production"
 const app = next({ dev })
@@ -8,7 +9,7 @@ const handle = app.getRequestHandler()
 app.prepare().then(() => {
   const server = express()
 
-  server.get("*.woff2?", (req, res) => {
+  server.get("*.woff2?", cors(), (req, res) => {
     res.setHeader("Cache-Control", "public,max-age=31536000,immutable")
     return handle(req, res)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,6 +3503,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -6012,7 +6020,7 @@ nprogress@^0.2.0:
   resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
   integrity sha1-y480xTIT2JVyP8urkH6UIq28r7E=
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -8111,7 +8119,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
I'm going to use the fonts served by flare (e.g. "https://www.wearseasons.com/fonts/apercu_mono-webfont.woff2") within the `try-with-seasons` widget. Because this widget can be running on potentially any domain (via an embedded iframe without an origin), we need to serve the fonts with cors headers.