### PR TITLE
fix: create .npmrc when building on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "NODE_ENV=production next start -p $PORT",
     "upload-assets": "node scripts/uploadAssetsToS3.js",
+    "heroku-prebuild": "echo \"//registry.npmjs.org/:_authToken=\\${NPM_TOKEN}\" >> .npmrc",
     "heroku-cleanup": "yarn upload-assets",
     "prettier": "prettier --write 'pages/**/*.{js,ts,tsx,md,graphql}' '*.{js,ts,tsx,md,graphql}' --ignore-path ./.prettierignore"
   },


### PR DESCRIPTION
Vercel does this for you [automatically](https://vercel.com/knowledge/using-private-dependencies-with-vercel#private-npm-dependencies), but for Heroku we need to [write a custom `.npmrc` file](https://devcenter.heroku.com/articles/nodejs-support#private-dependencies) for it to fill with the `NPM_TOKEN` env var we've set in the console.