### PR TITLE
hot-fix: Updates loading states

### DIFF
--- a/components/SignUp/DiscoverBagStep/DiscoverBagContent.tsx
+++ b/components/SignUp/DiscoverBagStep/DiscoverBagContent.tsx
@@ -232,7 +232,7 @@ export const DiscoverBagContent: React.FC<Props> = ({
           />
         )}
         disabled={false}
-        buttonText="Checkout"
+        buttonText="Next"
         secondaryButtonText={isDesktop ? "Continue later" : null}
         onSecondaryButtonClick={isDesktop ? onCompleted : null}
         handleSubmit={() => {

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -251,7 +251,6 @@ const SignUpPage = screenTrack(() => ({
             updateUserSession({ cust: { status: CustomerStatus.Active } })
             localStorage.setItem("paymentProcessed", "true")
             identify(data?.me?.customer?.user?.id, { status: "Active" })
-            refetchGetSignupUser()
             setCurrentStepState(Steps.FormConfirmation)
           }}
           onError={() => {}}


### PR DESCRIPTION
Fixes: 
- Users could click the submit payment button multiple times
- Adds a loader to the submit payment view
- Adds a refetch query to the payment step to ensure the customer status is accurate on the next view