### PR TITLE
fix: correctly check the users logged in status when creating draft order

### DIFF
--- a/components/Product/ProductBuyCTA.tsx
+++ b/components/Product/ProductBuyCTA.tsx
@@ -51,7 +51,7 @@ export const ProductBuyCTA = (props: Props) => {
   })
 
   const handleCreateDraftOrder = (orderType: "Used" | "New") => {
-    if (Boolean(authState?.userSession)) {
+    if (Boolean(authState?.isSignedIn)) {
       return createDraftOrder({
         variables: {
           input: {
@@ -70,6 +70,7 @@ export const ProductBuyCTA = (props: Props) => {
           hidePopUp()
         },
       })
+      return Promise.resolve()
     }
   }
 


### PR DESCRIPTION
`authState.userSession` is of shape `{ user: null }` when logged out, so the previous check I had here didn't actually work.