### PR TITLE
feat: tighten product grid item

### DIFF
--- a/components/Product/ProductGridItem.tsx
+++ b/components/Product/ProductGridItem.tsx
@@ -2,7 +2,6 @@ import React from "react"
 import styled from "styled-components"
 import { Box } from "../Box"
 import { Link } from "../Link"
-import { get } from "lodash"
 import { Sans } from "../Typography"
 import { VariantSizes } from "../VariantSizes"
 import ContentLoader from "react-content-loader"
@@ -10,7 +9,7 @@ import { ProgressiveImage } from "../Image"
 import { IMAGE_ASPECT_RATIO } from "../../utils/imageResize"
 import { Spacer } from "../Spacer"
 import { Schema, useTracking } from "utils/analytics"
-import { Picture } from "components"
+import { Picture, Flex } from "components"
 import { useAuthContext } from "lib/auth/AuthContext"
 
 type Props = {
@@ -59,10 +58,11 @@ export const ProductGridItem: React.FC<Props> = ({ product, loading }) => {
           <rect x={0} y={0} width="100%" height="100%" />
         </ContentLoader>
         <Spacer mb="3px" />
-        <ContentLoader width="100%" height="42px">
+        <ContentLoader width="100%" height="57px">
           <rect x={0} y={0} width="40%" height={10} />
           <rect x={0} y={15} width="53%" height={10} />
-          <rect x={0} y={30} width={60} height={10} />
+          <rect x={0} y={30} width="45%" height={10} />
+          <rect x={0} y={45} width={50} height={10} />
         </ContentLoader>
       </Box>
     )
@@ -99,27 +99,32 @@ export const ProductGridItem: React.FC<Props> = ({ product, loading }) => {
             </ThirdImageWrapper>
           )}
           <ProgressiveImage imageUrl={image?.url} size="small" alt={`Image of ${product.name}`} />
-          <Spacer mb={1} />
+          <Spacer mb={0.5} />
           <Link href="/designer/[Designer]" as={`/designer/${brandSlug}`}>
-            <Sans size="2" mt="0.5">
+            <LeadingNoneSans size="2" mt="0.5">
               {brandName}
-            </Sans>
+            </LeadingNoneSans>
           </Link>
-          <Sans size="2" mt="0.5" color="black50">
+          <Spacer mb={0.5} />
+          <LeadingNoneSans size="2" mt="0.5" color="black50">
             {name}
-          </Sans>
+          </LeadingNoneSans>
+          <Spacer mb={0.5} />
           {retailPrice && !authState?.isSignedIn && (
             <>
-              <LineThroughSans mt="0.5" size="2" color="black50" display="inline">
-                ${retailPrice}
-              </LineThroughSans>
-              <Sans mt="0.5" size="2" color="black50" display="inline">
-                {" "}
-                | $65 for 30-days
-              </Sans>
+              <Flex flexDirection="row">
+                <LineThroughSans mt="0.5" size="2" color="black50">
+                  ${retailPrice}
+                </LineThroughSans>
+                <LeadingNoneSans mt="0.5" size="2" color="black50">
+                  {" "}
+                  | $65 for 30-days
+                </LeadingNoneSans>
+              </Flex>
+              <Spacer mb={0.5} />
             </>
           )}
-          <VariantSizes variants={product.variants} size="2" />
+          <VariantSizes variants={product.variants} size="2" lineHeight="1" />
         </a>
       </Link>
     </ProductContainer>
@@ -128,6 +133,12 @@ export const ProductGridItem: React.FC<Props> = ({ product, loading }) => {
 
 const LineThroughSans = styled(Sans)`
   text-decoration: line-through;
+  line-height: 1;
+`
+
+const LeadingNoneSans = styled(Sans)`
+  white-space: pre;
+  line-height: 1;
 `
 
 const ThirdImageWrapper = styled(Box)<{ loaded: boolean }>`

--- a/components/VariantSizes.tsx
+++ b/components/VariantSizes.tsx
@@ -6,7 +6,8 @@ import { SansSize } from "../lib/theme"
 export const VariantSizes: React.FC<{
   variants: any[]
   size: SansSize
-}> = ({ variants, size }) => {
+  lineHeight?: string
+}> = ({ variants, size, lineHeight }) => {
   const availableVariants = variants.filter((a) => !!a?.internalSize?.display)
 
   return (
@@ -15,10 +16,10 @@ export const VariantSizes: React.FC<{
         const reservable = variant.reservable !== null && !!variant.reservable
         return (
           <Box key={variant.id} mr={1} style={{ position: "relative" }}>
-            <Sans size={size} color={reservable ? "black" : "black25"}>
+            <SansWithLineHeight size={size} color={reservable ? "black" : "black25"} lineHeight={lineHeight}>
               {variant?.internalSize?.display}
-            </Sans>
-            {!reservable && <Strikethrough size={size} />}
+            </SansWithLineHeight>
+            {!reservable && <Strikethrough size={size} lineHeight={lineHeight} />}
           </Box>
         )
       })}
@@ -26,11 +27,16 @@ export const VariantSizes: React.FC<{
   )
 }
 
-const Strikethrough = styled.div<{ size: SansSize }>`
+const SansWithLineHeight = styled(Sans)`
+  ${({ lineHeight }) => lineHeight && `line-height: ${lineHeight}`}
+`
+
+const Strikethrough = styled.div<{ size: SansSize; lineHeight?: string }>`
   background-color: ${color("black25")};
   height: 2px;
   width: 100%;
   position: absolute;
   top: ${(p) => (p.size === "3" ? 9 : 7)}px;
   left: 0;
+  ${({ lineHeight }) => lineHeight && `line-height: ${lineHeight}`}
 `


### PR DESCRIPTION
ensures a 4px top margin on product grid item copy by cropping the line height as close as possible (`1`) and manually adding spacers, vs relying on the empty space compose by the line heights of two copy elements.

![localhost_3000_browse_all+all_page=1](https://user-images.githubusercontent.com/5216744/115451164-d8ffe400-a1ea-11eb-833f-f2f93b0c85d5.png)
