### PR TITLE
Separates homepage query for specific me query

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,7 +16,7 @@ import { PartnerModal } from "components/Partner/PartnerModal"
 import { initializeApollo } from "lib/apollo/apollo"
 import { useAuthContext } from "lib/auth/AuthContext"
 import { useRouter } from "next/router"
-import { Home_Query } from "queries/homeQueries"
+import { HomeMe_Query, Home_Query } from "queries/homeQueries"
 import React, { useEffect, useRef } from "react"
 import { Schema, screenTrack } from "utils/analytics"
 import { imageResize } from "utils/imageResize"
@@ -32,7 +32,8 @@ const Home = screenTrack(() => ({
   page: Schema.PageNames.HomePage,
   path: "/",
 }))(() => {
-  const { previousData, data = previousData, refetch } = useQuery(Home_Query)
+  const { previousData, data = previousData } = useQuery(Home_Query)
+  const { previousData: mePreviousData, data: meData = mePreviousData, refetch: meRefetch } = useQuery(HomeMe_Query)
   const { updateUserSession, authState, toggleLoginModal } = useAuthContext()
   const router = useRouter()
 
@@ -44,15 +45,15 @@ const Home = screenTrack(() => ({
   const showPartnerModal = SHOW_PARTNER_MODAL_CAMPAIGNS.includes(router.query["utm_campaign"] as string)
 
   useEffect(() => {
-    if (!!data?.me?.customer) {
-      updateUserSession({ cust: data?.me?.customer })
+    if (!!meData?.me?.customer) {
+      updateUserSession({ cust: meData?.me?.customer })
     }
-  }, [data])
+  }, [meData])
 
   useEffect(() => {
     // Keep track of when a user signs in and refresh the page if they do
     if (isUserSignedIn !== userSignedIn.current) {
-      refetch()
+      meRefetch()
       userSignedIn.current = isUserSignedIn
     }
   }, [isUserSignedIn])

--- a/queries/homeQueries.ts
+++ b/queries/homeQueries.ts
@@ -32,8 +32,8 @@ const HomePageProductFragment_Product = gql`
   ${ProductGridItem_Product}
 `
 
-export const Home_Query = gql`
-  query Home_Query {
+export const HomeMe_Query = gql`
+  query HomeMe_Query {
     me {
       id
       customer {
@@ -47,6 +47,11 @@ export const Home_Query = gql`
         }
       }
     }
+  }
+`
+
+export const Home_Query = gql`
+  query Home_Query {
     collections(orderBy: updatedAt_DESC, first: 1, where: { published: true }) {
       id
       slug


### PR DESCRIPTION
- Moves `me` resolver in the homepage query to its own query so we can cache the main query