### PR TITLE
chore: enable unavailable variants to be selected

### DIFF
--- a/components/Product/VariantSelect.tsx
+++ b/components/Product/VariantSelect.tsx
@@ -52,10 +52,8 @@ export const VariantList = ({ setSelectedVariant, selectedVariant, onSizeSelecte
               size: size?.internalSize?.display,
               variantID: size?.id,
             })
-            if (size.reservable > 0) {
-              setSelectedVariant(size)
-              onSizeSelected(size)
-            }
+            setSelectedVariant(size)
+            onSizeSelected(size)
           }}
         >
           <Flex flexDirection="row" alignItems="center" justifyContent="space-between" flexWrap="nowrap" mr={2}>


### PR DESCRIPTION
This mirrors the logic in harvest (https://github.com/seasons/harvest/blob/master/src/Scenes/Product/Components/VariantList.tsx#L52-L59), though the add to bag button remains disabled instead of prompting "notify me"