### PR TITLE
remove isWanted from product query

### DIFF
--- a/pages/product/[Product].tsx
+++ b/pages/product/[Product].tsx
@@ -60,7 +60,6 @@ const Product = screenTrack(({ router }) => {
       size: "",
       stock: 0,
       isInBag: false,
-      isWanted: false,
     }
   )
 

--- a/queries/productQueries.ts
+++ b/queries/productQueries.ts
@@ -57,7 +57,6 @@ export const GET_PRODUCT = gql`
         reserved
         isInBag
         isSaved
-        isWanted
         manufacturerSizes {
           id
           display


### PR DESCRIPTION
We long ago deprecated `isWanted` in favor of `hasRestockNotification`, but we've continued to query it. This PR removes that query in the name of efficiency.