### PR TITLE
Resets page to 1 on filters

### DIFF
--- a/components/Browse/AvailabilityFilters.tsx
+++ b/components/Browse/AvailabilityFilters.tsx
@@ -15,7 +15,7 @@ export const AvailabilityFilters = ({ setParams, params, breakpoint }) => {
       <FlexWrapper mb={isMobile ? 0 : 2}>
         <Checkbox
           onClick={() => {
-            setParams({ ...params, available: !available })
+            setParams({ ...params, available: !available, page: 1 })
           }}
           isActive={available}
         />
@@ -26,7 +26,7 @@ export const AvailabilityFilters = ({ setParams, params, breakpoint }) => {
       <FlexWrapper mb={isMobile ? 0 : 5}>
         <Checkbox
           onClick={() => {
-            setParams({ ...params, forSaleOnly: !forSaleOnly })
+            setParams({ ...params, forSaleOnly: !forSaleOnly, page: 1 })
           }}
           isActive={forSaleOnly}
         />

--- a/components/Browse/BrowseSizeFilters.tsx
+++ b/components/Browse/BrowseSizeFilters.tsx
@@ -27,9 +27,9 @@ const SizeButton: React.FC<SizeButtonProps> = ({ size, items, setParams, params,
       onClick={() => {
         const newParamsArray = isActive ? itemArray.filter((i) => i !== size) : [size, ...itemArray]
         if (type === "bottoms") {
-          setParams({ ...params, bottoms: newParamsArray })
+          setParams({ ...params, bottoms: newParamsArray, page: 1 })
         } else {
-          setParams({ ...params, tops: newParamsArray })
+          setParams({ ...params, tops: newParamsArray, page: 1 })
         }
       }}
     >

--- a/components/Browse/ColorFilters.tsx
+++ b/components/Browse/ColorFilters.tsx
@@ -43,7 +43,7 @@ export const ColorFilters: React.FC<Props> = ({ setParams, params }) => {
                 const newColors: string[] = isActive
                   ? params?.colors?.filter((i) => i !== color.name)
                   : [color.name, ...currentColors]
-                setParams({ ...params, colors: newColors })
+                setParams({ ...params, colors: newColors, page: 1 })
               }}
             >
               <Sans size="3" my="2" color={isActive ? themeColor("white100") : themeColor("black100")}>

--- a/components/Browse/PriceFilters.tsx
+++ b/components/Browse/PriceFilters.tsx
@@ -28,7 +28,7 @@ export const PriceFilters = ({ setParams, params }) => {
         <Box my={1}>
           <Flex
             onClick={() => {
-              setParams({ ...params, priceRange: option.value })
+              setParams({ ...params, priceRange: option.value, page: 1 })
             }}
             alignItems="center"
           >

--- a/pages/browse/[Filter].tsx
+++ b/pages/browse/[Filter].tsx
@@ -253,7 +253,7 @@ export const BrowsePage: NextPage<{}> = screenTrack(() => ({
           <MobileFilters
             BrandsListComponent={
               <BrowseFilters
-                setParam={(brandName) => onSetParams({ ...params, brandName })}
+                setParam={(brandName) => onSetParams({ ...params, brandName, page: 1 })}
                 listItems={brands}
                 title="Designers"
                 hideTitle
@@ -271,7 +271,7 @@ export const BrowsePage: NextPage<{}> = screenTrack(() => ({
             }
             CategoriesListComponent={
               <BrowseFilters
-                setParam={(categoryName) => onSetParams({ ...params, categoryName })}
+                setParam={(categoryName) => onSetParams({ ...params, categoryName, page: 1 })}
                 title="Categories"
                 currentCategory={categoryName}
                 listItems={categories}
@@ -300,7 +300,7 @@ export const BrowsePage: NextPage<{}> = screenTrack(() => ({
                     <BrowseFilters
                       currentCategory={categoryName}
                       title="Categories"
-                      setParam={(categoryName) => onSetParams({ ...params, categoryName })}
+                      setParam={(categoryName) => onSetParams({ ...params, categoryName, page: 1 })}
                       listItems={categories}
                       currentBrand={brandName}
                     />
@@ -315,7 +315,7 @@ export const BrowsePage: NextPage<{}> = screenTrack(() => ({
                     <Spacer mb={5} />
                     <BrowseFilters
                       title="Designers"
-                      setParam={(brandName) => onSetParams({ ...params, brandName })}
+                      setParam={(brandName) => onSetParams({ ...params, brandName, page: 1 })}
                       currentCategory={categoryName}
                       listItems={brands}
                       currentBrand={brandName}


### PR DESCRIPTION
- We weren't resetting the page to 1 when new filters were selected so often it would appear as there were no results.